### PR TITLE
fix: use `<time>` tag

### DIFF
--- a/test/templates/bits/lastmod.tmpl
+++ b/test/templates/bits/lastmod.tmpl
@@ -1,1 +1,1 @@
-Last modified: %{lastmodified} <br>
+Last modified: <time>%{lastmodified}</time> <br>

--- a/test/templates/blog/entrydate.tmpl
+++ b/test/templates/blog/entrydate.tmpl
@@ -1,1 +1,1 @@
-<div class="posttitle" style="opacity: 0.6;"><small>@{blog::namedate}</small></div>
+<div class="posttitle" style="opacity: 0.6;"><small><time>@{blog::namedate}</time></small></div>


### PR DESCRIPTION
## Summary

adds [`<time>`](https://developer.mozilla.org/docs/Web/HTML/Element/time) tag in order to be more accessible. will do [`datetime`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#attributes) attribute in following PR.
 
## Rationale

https://shkspr.mobi/blog/2020/12/making-time-more-accessible/